### PR TITLE
feat(connection): implement connection managers with retry logic

### DIFF
--- a/docs/CONNECTION_MANAGER.md
+++ b/docs/CONNECTION_MANAGER.md
@@ -1,0 +1,484 @@
+# Connection Manager Guide
+
+This guide explains how to use the connection managers for Neo4j and Graphiti with automatic retry logic, connection pooling, and error handling.
+
+## Overview
+
+The connection management system provides:
+
+- **Automatic retry logic** for transient failures
+- **Connection pooling** for efficient resource usage
+- **State tracking** with callbacks for monitoring
+- **Metrics collection** for performance analysis
+- **Both sync and async** connection support
+- **Context managers** for safe resource handling
+
+## Components
+
+### Neo4jConnectionManager
+
+Manages connections to Neo4j database with features:
+- Automatic reconnection on failure
+- Session management with retry logic
+- Query execution helpers
+- Connection state tracking
+- Performance metrics
+
+### GraphitiConnectionManager
+
+Manages connections to Graphiti service with features:
+- HTTP client with retry logic
+- Request helpers with automatic retries
+- Health check verification
+- Connection state tracking
+- Performance metrics
+
+### ConnectionPool
+
+Generic connection pooling for any manager type:
+- Configurable pool size
+- Connection reuse
+- Thread-safe acquisition
+- Timeout support
+
+## Basic Usage
+
+### Simple Query Execution
+
+```python
+from graphiti_connection import get_neo4j_connection
+
+# Get global connection manager
+neo4j = get_neo4j_connection()
+
+# Execute a query with automatic retry
+results = neo4j.execute_query(
+    "MATCH (n:Person) WHERE n.age > $age RETURN n.name as name",
+    {"age": 25}
+)
+
+for record in results:
+    print(f"Name: {record['name']}")
+```
+
+### Using Sessions
+
+```python
+from graphiti_connection import Neo4jConnectionManager
+
+manager = Neo4jConnectionManager()
+
+# Session with automatic cleanup
+with manager.session() as session:
+    # Run queries in transaction
+    session.run("CREATE (n:Person {name: $name})", {"name": "Alice"})
+    
+    result = session.run("MATCH (n:Person) RETURN count(n) as count")
+    count = result.single()["count"]
+    print(f"Total persons: {count}")
+```
+
+### Making HTTP Requests
+
+```python
+from graphiti_connection import get_graphiti_connection
+
+# Get global connection manager
+graphiti = get_graphiti_connection()
+
+# Make request with automatic retry
+response = graphiti.request("POST", "/api/entities", json={
+    "type": "Question",
+    "content": "What is Python?",
+    "metadata": {"difficulty": "medium"}
+})
+
+if response.status_code == 201:
+    entity = response.json()
+    print(f"Created entity: {entity['id']}")
+```
+
+## Async Usage
+
+### Async Queries
+
+```python
+import asyncio
+from graphiti_connection import Neo4jConnectionManager
+
+async def async_example():
+    manager = Neo4jConnectionManager()
+    
+    # Async query execution
+    results = await manager.execute_query_async(
+        "MATCH (n:Person) RETURN n.name as name LIMIT 10"
+    )
+    
+    for record in results:
+        print(f"Name: {record['name']}")
+    
+    # Async session
+    async with manager.async_session() as session:
+        result = await session.run("RETURN 'Hello async!' as message")
+        async for record in result:
+            print(record["message"])
+    
+    await manager.close_async()
+
+# Run async function
+asyncio.run(async_example())
+```
+
+### Async HTTP Requests
+
+```python
+async def graphiti_async():
+    manager = GraphitiConnectionManager()
+    
+    # Async request
+    response = await manager.request_async("GET", "/api/status")
+    status = response.json()
+    
+    await manager.close_async()
+```
+
+## Connection Pooling
+
+### Basic Pool Usage
+
+```python
+from graphiti_connection import ConnectionPool, Neo4jConnectionManager
+
+# Create pool with 5 connections
+pool = ConnectionPool(Neo4jConnectionManager, size=5)
+
+# Acquire connection from pool
+with pool.acquire() as conn:
+    results = conn.execute_query("RETURN 1")
+    # Connection automatically returned to pool
+
+# Pool can handle concurrent requests
+import concurrent.futures
+
+def worker(query):
+    with pool.acquire() as conn:
+        return conn.execute_query(query)
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+    futures = [executor.submit(worker, f"RETURN {i}") for i in range(10)]
+    results = [f.result() for f in futures]
+
+# Clean up
+pool.close()
+```
+
+### Pool with Timeout
+
+```python
+try:
+    # Acquire with timeout
+    with pool.acquire(timeout=5.0) as conn:
+        # Use connection
+        pass
+except TimeoutError:
+    print("Failed to acquire connection within 5 seconds")
+```
+
+## Error Handling
+
+### Automatic Retries
+
+The connection managers automatically retry on transient failures:
+
+```python
+# Configure retry behavior in config
+config.graphiti.max_retries = 5
+config.graphiti.retry_delay = 2.0
+config.graphiti.retry_backoff = 2.0
+
+manager = GraphitiConnectionManager(config)
+
+# This will retry up to 5 times with exponential backoff
+try:
+    response = manager.request("GET", "/api/data")
+except Exception as e:
+    print(f"Failed after {manager.metrics.total_retries} retries: {e}")
+```
+
+### Manual Retry Control
+
+```python
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(1),
+)
+def custom_operation(manager):
+    with manager.session() as session:
+        return session.run("MATCH (n) RETURN n LIMIT 1")
+
+# Use with custom retry logic
+try:
+    result = custom_operation(neo4j_manager)
+except Exception as e:
+    print(f"Operation failed: {e}")
+```
+
+## Monitoring and Metrics
+
+### Connection State Monitoring
+
+```python
+from graphiti_connection import ConnectionState
+
+def on_state_change(state: ConnectionState):
+    if state == ConnectionState.CONNECTED:
+        print("✅ Connected successfully")
+    elif state == ConnectionState.FAILED:
+        print("❌ Connection failed")
+    elif state == ConnectionState.CONNECTING:
+        print("⏳ Connecting...")
+
+manager = Neo4jConnectionManager()
+manager.add_state_callback(on_state_change)
+
+# State changes will trigger callback
+manager.connect()
+```
+
+### Performance Metrics
+
+```python
+# After using connection
+metrics = manager.metrics
+
+print(f"Total connections: {metrics.total_connections}")
+print(f"Successful: {metrics.successful_connections}")
+print(f"Failed: {metrics.failed_connections}")
+print(f"Success rate: {metrics.success_rate:.2%}")
+print(f"Total retries: {metrics.total_retries}")
+print(f"Last error: {metrics.last_error}")
+print(f"Connection time: {metrics.connection_duration:.2f}s")
+```
+
+## Configuration
+
+### Connection Settings
+
+Configure connection behavior through environment variables:
+
+```bash
+# Neo4j settings
+NEO4J_MAX_CONNECTION_LIFETIME=3600
+NEO4J_MAX_CONNECTION_POOL_SIZE=50
+NEO4J_CONNECTION_ACQUISITION_TIMEOUT=60
+
+# Graphiti settings
+GRAPHITI_REQUEST_TIMEOUT=30
+GRAPHITI_MAX_RETRIES=3
+GRAPHITI_RETRY_DELAY=1.0
+GRAPHITI_RETRY_BACKOFF=2.0
+```
+
+### Custom Configuration
+
+```python
+from graphiti_config import RuntimeConfig, Neo4jConfig
+
+# Create custom config
+config = RuntimeConfig()
+config.neo4j.max_connection_pool_size = 100
+config.neo4j.connection_acquisition_timeout = 30
+
+# Use with manager
+manager = Neo4jConnectionManager(config)
+```
+
+## Best Practices
+
+### 1. Use Global Managers
+
+```python
+# ✅ Good - reuses connection
+neo4j = get_neo4j_connection()
+results1 = neo4j.execute_query("RETURN 1")
+results2 = neo4j.execute_query("RETURN 2")
+
+# ❌ Bad - creates multiple connections
+manager1 = Neo4jConnectionManager()
+results1 = manager1.execute_query("RETURN 1")
+manager2 = Neo4jConnectionManager()
+results2 = manager2.execute_query("RETURN 2")
+```
+
+### 2. Always Use Context Managers
+
+```python
+# ✅ Good - automatic cleanup
+with manager.session() as session:
+    session.run(query)
+
+# ❌ Bad - manual cleanup required
+session = manager._driver.session()
+session.run(query)
+session.close()  # Easy to forget
+```
+
+### 3. Handle Connection Failures
+
+```python
+def resilient_operation():
+    try:
+        manager = get_neo4j_connection()
+        return manager.execute_query("MATCH (n) RETURN n")
+    except Exception as e:
+        logger.error(f"Operation failed: {e}")
+        # Fallback behavior
+        return []
+```
+
+### 4. Monitor Connection Health
+
+```python
+import time
+
+def health_check():
+    manager = get_neo4j_connection()
+    
+    try:
+        start = time.time()
+        manager.execute_query("RETURN 1")
+        duration = time.time() - start
+        
+        return {
+            "status": "healthy",
+            "response_time": duration,
+            "success_rate": manager.metrics.success_rate
+        }
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "error": str(e),
+            "last_error": manager.metrics.last_error
+        }
+```
+
+### 5. Clean Up Resources
+
+```python
+import atexit
+from graphiti_connection import close_all_connections
+
+# Register cleanup on exit
+atexit.register(close_all_connections)
+
+# Or in async context
+async def cleanup():
+    await close_all_connections_async()
+```
+
+## Troubleshooting
+
+### Connection Timeouts
+
+If connections are timing out:
+1. Increase `connection_acquisition_timeout`
+2. Check network connectivity
+3. Verify service is running
+4. Check connection pool size
+
+### Retry Exhaustion
+
+If retries are exhausted:
+1. Increase `max_retries` in configuration
+2. Adjust `retry_delay` and `retry_backoff`
+3. Check for persistent service issues
+4. Implement circuit breaker pattern
+
+### Memory Leaks
+
+Prevent connection leaks:
+1. Always use context managers
+2. Call `close()` in finally blocks
+3. Monitor pool size
+4. Use global managers
+
+### Performance Issues
+
+For better performance:
+1. Increase connection pool size
+2. Reuse connections
+3. Batch operations
+4. Use async for I/O heavy workloads
+
+## Advanced Topics
+
+### Custom Retry Strategies
+
+```python
+from tenacity import retry_if_result
+
+def is_retriable_error(exception):
+    return isinstance(exception, (ServiceUnavailable, TransientError))
+
+@retry(
+    retry=retry_if_exception_type(is_retriable_error),
+    stop=stop_after_attempt(5),
+)
+def custom_query(manager, query):
+    return manager.execute_query(query)
+```
+
+### Connection Warmup
+
+```python
+def warmup_connections(pool_size=5):
+    pool = ConnectionPool(Neo4jConnectionManager, size=pool_size)
+    
+    # Pre-create all connections
+    connections = []
+    for _ in range(pool_size):
+        with pool.acquire() as conn:
+            conn.execute_query("RETURN 1")
+            connections.append(conn)
+    
+    logger.info(f"Warmed up {pool_size} connections")
+    return pool
+```
+
+### Circuit Breaker Pattern
+
+```python
+from datetime import datetime, timedelta
+
+class CircuitBreaker:
+    def __init__(self, failure_threshold=5, recovery_timeout=60):
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.failure_count = 0
+        self.last_failure_time = None
+        self.is_open = False
+    
+    def call(self, func, *args, **kwargs):
+        if self.is_open:
+            if datetime.now() - self.last_failure_time > timedelta(seconds=self.recovery_timeout):
+                self.is_open = False
+                self.failure_count = 0
+            else:
+                raise Exception("Circuit breaker is open")
+        
+        try:
+            result = func(*args, **kwargs)
+            self.failure_count = 0
+            return result
+        except Exception as e:
+            self.failure_count += 1
+            self.last_failure_time = datetime.now()
+            
+            if self.failure_count >= self.failure_threshold:
+                self.is_open = True
+                logger.error("Circuit breaker opened")
+            
+            raise e
+```

--- a/examples/connection_usage.py
+++ b/examples/connection_usage.py
@@ -1,0 +1,235 @@
+"""
+Example usage of the Graphiti connection manager.
+
+This script demonstrates how to use the connection managers
+for both Neo4j and Graphiti with automatic retry logic.
+"""
+
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+from graphiti_connection import (
+    Neo4jConnectionManager,
+    GraphitiConnectionManager,
+    ConnectionPool,
+    get_neo4j_connection,
+    get_graphiti_connection,
+    ConnectionState,
+)
+from graphiti_config import get_config
+
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def neo4j_example():
+    """Example of using Neo4j connection manager."""
+    logger.info("=== Neo4j Connection Example ===")
+    
+    # Get global connection manager
+    neo4j = get_neo4j_connection()
+    
+    # Add state change callback
+    def on_state_change(state: ConnectionState):
+        logger.info(f"Neo4j connection state changed to: {state.value}")
+    
+    neo4j.add_state_callback(on_state_change)
+    
+    try:
+        # Simple query execution
+        logger.info("Executing simple query...")
+        results = neo4j.execute_query(
+            "RETURN 'Hello from Neo4j!' as message, datetime() as timestamp"
+        )
+        for record in results:
+            logger.info(f"Result: {record}")
+        
+        # Using session context manager
+        logger.info("Using session for transaction...")
+        with neo4j.session() as session:
+            # Create some test data
+            session.run(
+                "CREATE (n:TestNode {name: $name, created: datetime()})",
+                {"name": "Example Node"}
+            )
+            
+            # Query the data
+            result = session.run("MATCH (n:TestNode) RETURN n.name as name")
+            names = [record["name"] for record in result]
+            logger.info(f"Found nodes: {names}")
+            
+            # Clean up
+            session.run("MATCH (n:TestNode) DELETE n")
+        
+        # Check metrics
+        metrics = neo4j.metrics
+        logger.info(f"Connection metrics:")
+        logger.info(f"  Total connections: {metrics.total_connections}")
+        logger.info(f"  Success rate: {metrics.success_rate:.2%}")
+        logger.info(f"  Total retries: {metrics.total_retries}")
+        
+    except Exception as e:
+        logger.error(f"Neo4j error: {e}")
+    finally:
+        neo4j.close()
+
+
+def graphiti_example():
+    """Example of using Graphiti connection manager."""
+    logger.info("\n=== Graphiti Connection Example ===")
+    
+    # Get global connection manager
+    graphiti = get_graphiti_connection()
+    
+    try:
+        # Make API requests with automatic retry
+        logger.info("Making Graphiti API request...")
+        
+        # Health check
+        response = graphiti.request("GET", "/health")
+        logger.info(f"Health check status: {response.status_code}")
+        
+        # Example entity creation (adjust based on actual API)
+        entity_data = {
+            "type": "Question",
+            "content": "What is the capital of France?",
+            "metadata": {
+                "difficulty": "easy",
+                "category": "geography"
+            }
+        }
+        
+        # This would create an entity if the endpoint exists
+        # response = graphiti.request("POST", "/api/entities", json=entity_data)
+        # logger.info(f"Entity creation status: {response.status_code}")
+        
+        # Check metrics
+        metrics = graphiti.metrics
+        logger.info(f"Connection metrics:")
+        logger.info(f"  Total connections: {metrics.total_connections}")
+        logger.info(f"  Success rate: {metrics.success_rate:.2%}")
+        logger.info(f"  Total retries: {metrics.total_retries}")
+        
+    except Exception as e:
+        logger.error(f"Graphiti error: {e}")
+    finally:
+        graphiti.close()
+
+
+async def async_example():
+    """Example of async connection usage."""
+    logger.info("\n=== Async Connection Example ===")
+    
+    # Neo4j async example
+    neo4j = Neo4jConnectionManager()
+    
+    try:
+        # Async query execution
+        results = await neo4j.execute_query_async(
+            "UNWIND range(1, 5) as n RETURN n, n * n as square"
+        )
+        logger.info("Async query results:")
+        for record in results:
+            logger.info(f"  {record['n']} squared = {record['square']}")
+        
+        # Async session usage
+        async with neo4j.async_session() as session:
+            result = await session.run(
+                "RETURN $message as msg",
+                {"message": "Hello from async Neo4j!"}
+            )
+            async for record in result:
+                logger.info(f"Async message: {record['msg']}")
+    
+    finally:
+        await neo4j.close_async()
+    
+    # Graphiti async example
+    graphiti = GraphitiConnectionManager()
+    
+    try:
+        # Async HTTP request
+        response = await graphiti.request_async("GET", "/health")
+        logger.info(f"Async health check: {response.status_code}")
+    
+    finally:
+        await graphiti.close_async()
+
+
+def connection_pool_example():
+    """Example of using connection pools."""
+    logger.info("\n=== Connection Pool Example ===")
+    
+    # Create a connection pool for Neo4j
+    pool = ConnectionPool(Neo4jConnectionManager, size=3)
+    
+    try:
+        # Simulate multiple concurrent operations
+        logger.info("Acquiring connections from pool...")
+        
+        with pool.acquire() as conn1:
+            logger.info(f"Connection 1 state: {conn1.state.value}")
+            results = conn1.execute_query("RETURN 1 as num")
+            logger.info(f"Connection 1 result: {results}")
+            
+            with pool.acquire() as conn2:
+                logger.info(f"Connection 2 state: {conn2.state.value}")
+                results = conn2.execute_query("RETURN 2 as num")
+                logger.info(f"Connection 2 result: {results}")
+        
+        # Connections are returned to pool after use
+        logger.info("Connections returned to pool")
+        
+        # Reuse connection
+        with pool.acquire() as conn3:
+            logger.info("Reusing connection from pool")
+            results = conn3.execute_query("RETURN 3 as num")
+            logger.info(f"Reused connection result: {results}")
+    
+    finally:
+        pool.close()
+        logger.info("Connection pool closed")
+
+
+def error_handling_example():
+    """Example of error handling and retry behavior."""
+    logger.info("\n=== Error Handling Example ===")
+    
+    config = get_config()
+    
+    # Simulate connection to non-existent server
+    config.neo4j.uri = "bolt://nonexistent:7687"
+    neo4j = Neo4jConnectionManager(config)
+    
+    try:
+        # This will retry 3 times before failing
+        neo4j.connect()
+    except Exception as e:
+        logger.error(f"Expected connection failure: {e}")
+        logger.info(f"Failed after {neo4j.metrics.total_connections} attempts")
+        logger.info(f"Total retries: {neo4j.metrics.total_retries}")
+
+
+def main():
+    """Run all examples."""
+    # Synchronous examples
+    neo4j_example()
+    graphiti_example()
+    connection_pool_example()
+    error_handling_example()
+    
+    # Asynchronous examples
+    logger.info("\n=== Running Async Examples ===")
+    asyncio.run(async_example())
+    
+    logger.info("\n=== All Examples Completed ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/graphiti_connection.py
+++ b/graphiti_connection.py
@@ -1,0 +1,632 @@
+"""
+Connection manager for Neo4j and Graphiti with retry logic.
+
+This module provides robust connection management with automatic retries,
+connection pooling, and graceful error handling for both Neo4j database
+and Graphiti service connections.
+"""
+
+import asyncio
+import time
+import logging
+from typing import Optional, Dict, Any, List, Callable, TypeVar, Union
+from dataclasses import dataclass, field
+from contextlib import contextmanager, asynccontextmanager
+from functools import wraps
+from enum import Enum
+import threading
+
+from neo4j import GraphDatabase, Driver, Session, AsyncGraphDatabase, AsyncDriver, AsyncSession
+from neo4j.exceptions import (
+    Neo4jError,
+    ServiceUnavailable,
+    SessionExpired,
+    TransientError,
+    AuthError,
+)
+import httpx
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_exponential,
+    retry_if_exception_type,
+    before_sleep_log,
+    after_log,
+)
+
+from graphiti_config import get_config, RuntimeConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+T = TypeVar('T')
+
+
+class ConnectionState(str, Enum):
+    """Connection state enumeration."""
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    FAILED = "failed"
+    CLOSED = "closed"
+
+
+@dataclass
+class ConnectionMetrics:
+    """Metrics for connection monitoring."""
+    total_connections: int = 0
+    successful_connections: int = 0
+    failed_connections: int = 0
+    total_retries: int = 0
+    last_connection_time: Optional[float] = None
+    last_failure_time: Optional[float] = None
+    last_error: Optional[str] = None
+    connection_duration: float = 0.0
+    
+    def record_success(self, duration: float):
+        """Record successful connection."""
+        self.total_connections += 1
+        self.successful_connections += 1
+        self.last_connection_time = time.time()
+        self.connection_duration = duration
+    
+    def record_failure(self, error: str):
+        """Record failed connection."""
+        self.total_connections += 1
+        self.failed_connections += 1
+        self.last_failure_time = time.time()
+        self.last_error = error
+    
+    def record_retry(self):
+        """Record retry attempt."""
+        self.total_retries += 1
+    
+    @property
+    def success_rate(self) -> float:
+        """Calculate connection success rate."""
+        if self.total_connections == 0:
+            return 0.0
+        return self.successful_connections / self.total_connections
+
+
+class Neo4jConnectionManager:
+    """Manages Neo4j database connections with retry logic."""
+    
+    def __init__(self, config: Optional[RuntimeConfig] = None):
+        """Initialize connection manager."""
+        self.config = config or get_config()
+        self._driver: Optional[Driver] = None
+        self._async_driver: Optional[AsyncDriver] = None
+        self._state = ConnectionState.DISCONNECTED
+        self._metrics = ConnectionMetrics()
+        self._lock = threading.Lock()
+        self._callbacks: List[Callable[[ConnectionState], None]] = []
+    
+    @property
+    def state(self) -> ConnectionState:
+        """Get current connection state."""
+        return self._state
+    
+    @property
+    def metrics(self) -> ConnectionMetrics:
+        """Get connection metrics."""
+        return self._metrics
+    
+    def add_state_callback(self, callback: Callable[[ConnectionState], None]):
+        """Add callback for state changes."""
+        self._callbacks.append(callback)
+    
+    def _set_state(self, state: ConnectionState):
+        """Set connection state and notify callbacks."""
+        self._state = state
+        for callback in self._callbacks:
+            try:
+                callback(state)
+            except Exception as e:
+                logger.error(f"Error in state callback: {e}")
+    
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((ServiceUnavailable, ConnectionError)),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        after=after_log(logger, logging.INFO),
+    )
+    def connect(self) -> Driver:
+        """Connect to Neo4j with retry logic."""
+        start_time = time.time()
+        self._set_state(ConnectionState.CONNECTING)
+        
+        try:
+            if not self.config.validate_neo4j_connection():
+                raise ValueError("Invalid Neo4j configuration")
+            
+            with self._lock:
+                if self._driver is None:
+                    logger.info(f"Connecting to Neo4j at {self.config.neo4j.uri}")
+                    self._driver = GraphDatabase.driver(
+                        **self.config.get_neo4j_config()
+                    )
+                    
+                    # Verify connectivity
+                    self._driver.verify_connectivity()
+                    
+                    duration = time.time() - start_time
+                    self._metrics.record_success(duration)
+                    self._set_state(ConnectionState.CONNECTED)
+                    logger.info(f"Connected to Neo4j in {duration:.2f}s")
+                
+                return self._driver
+                
+        except Exception as e:
+            self._metrics.record_failure(str(e))
+            self._set_state(ConnectionState.FAILED)
+            logger.error(f"Failed to connect to Neo4j: {e}")
+            raise
+    
+    async def connect_async(self) -> AsyncDriver:
+        """Connect to Neo4j asynchronously with retry logic."""
+        start_time = time.time()
+        self._set_state(ConnectionState.CONNECTING)
+        
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception_type((ServiceUnavailable, ConnectionError)),
+        )
+        async def _connect():
+            if not self.config.validate_neo4j_connection():
+                raise ValueError("Invalid Neo4j configuration")
+            
+            if self._async_driver is None:
+                logger.info(f"Connecting to Neo4j async at {self.config.neo4j.uri}")
+                self._async_driver = AsyncGraphDatabase.driver(
+                    **self.config.get_neo4j_config()
+                )
+                
+                # Verify connectivity
+                await self._async_driver.verify_connectivity()
+                
+                duration = time.time() - start_time
+                self._metrics.record_success(duration)
+                self._set_state(ConnectionState.CONNECTED)
+                logger.info(f"Connected to Neo4j async in {duration:.2f}s")
+            
+            return self._async_driver
+        
+        try:
+            return await _connect()
+        except Exception as e:
+            self._metrics.record_failure(str(e))
+            self._set_state(ConnectionState.FAILED)
+            logger.error(f"Failed to connect to Neo4j async: {e}")
+            raise
+    
+    @contextmanager
+    def session(self, **kwargs) -> Session:
+        """Create a Neo4j session with automatic retry."""
+        driver = self.connect()
+        session = None
+        
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+            retry=retry_if_exception_type((SessionExpired, TransientError)),
+        )
+        def _create_session():
+            nonlocal session
+            session = driver.session(**kwargs)
+            return session
+        
+        try:
+            yield _create_session()
+        finally:
+            if session:
+                session.close()
+    
+    @asynccontextmanager
+    async def async_session(self, **kwargs) -> AsyncSession:
+        """Create an async Neo4j session with automatic retry."""
+        driver = await self.connect_async()
+        session = None
+        
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+            retry=retry_if_exception_type((SessionExpired, TransientError)),
+        )
+        async def _create_session():
+            nonlocal session
+            session = await driver.session(**kwargs)
+            return session
+        
+        try:
+            yield await _create_session()
+        finally:
+            if session:
+                await session.close()
+    
+    def execute_query(self, query: str, parameters: Optional[Dict[str, Any]] = None, **kwargs) -> List[Dict[str, Any]]:
+        """Execute a query with automatic retry and connection management."""
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+            retry=retry_if_exception_type((SessionExpired, TransientError, ServiceUnavailable)),
+            before_sleep=lambda retry_state: self._metrics.record_retry(),
+        )
+        def _execute():
+            with self.session() as session:
+                result = session.run(query, parameters or {})
+                return [dict(record) for record in result]
+        
+        return _execute()
+    
+    async def execute_query_async(self, query: str, parameters: Optional[Dict[str, Any]] = None, **kwargs) -> List[Dict[str, Any]]:
+        """Execute a query asynchronously with automatic retry."""
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+            retry=retry_if_exception_type((SessionExpired, TransientError, ServiceUnavailable)),
+            before_sleep=lambda retry_state: self._metrics.record_retry(),
+        )
+        async def _execute():
+            async with self.async_session() as session:
+                result = await session.run(query, parameters or {})
+                records = []
+                async for record in result:
+                    records.append(dict(record))
+                return records
+        
+        return await _execute()
+    
+    def close(self):
+        """Close the connection."""
+        with self._lock:
+            if self._driver:
+                self._driver.close()
+                self._driver = None
+            if self._async_driver:
+                # Async driver close needs to be handled in async context
+                logger.warning("Async driver should be closed in async context")
+            self._set_state(ConnectionState.CLOSED)
+            logger.info("Neo4j connection closed")
+    
+    async def close_async(self):
+        """Close the connection asynchronously."""
+        if self._driver:
+            self._driver.close()
+            self._driver = None
+        if self._async_driver:
+            await self._async_driver.close()
+            self._async_driver = None
+        self._set_state(ConnectionState.CLOSED)
+        logger.info("Neo4j connections closed")
+    
+    def __enter__(self):
+        """Context manager entry."""
+        self.connect()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        await self.connect_async()
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await self.close_async()
+
+
+class GraphitiConnectionManager:
+    """Manages Graphiti service connections with retry logic."""
+    
+    def __init__(self, config: Optional[RuntimeConfig] = None):
+        """Initialize connection manager."""
+        self.config = config or get_config()
+        self._client: Optional[httpx.Client] = None
+        self._async_client: Optional[httpx.AsyncClient] = None
+        self._state = ConnectionState.DISCONNECTED
+        self._metrics = ConnectionMetrics()
+    
+    @property
+    def state(self) -> ConnectionState:
+        """Get current connection state."""
+        return self._state
+    
+    @property
+    def metrics(self) -> ConnectionMetrics:
+        """Get connection metrics."""
+        return self._metrics
+    
+    def _create_client_kwargs(self) -> Dict[str, Any]:
+        """Create client configuration."""
+        return {
+            "base_url": self.config.graphiti.endpoint,
+            "headers": self.config.get_graphiti_headers(),
+            "timeout": httpx.Timeout(
+                self.config.graphiti.request_timeout,
+                connect=10.0,
+            ),
+        }
+    
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((httpx.ConnectError, httpx.TimeoutException)),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+    def connect(self) -> httpx.Client:
+        """Connect to Graphiti service with retry logic."""
+        start_time = time.time()
+        self._state = ConnectionState.CONNECTING
+        
+        try:
+            if not self.config.validate_graphiti_connection():
+                raise ValueError("Invalid Graphiti configuration")
+            
+            if self._client is None:
+                logger.info(f"Connecting to Graphiti at {self.config.graphiti.endpoint}")
+                self._client = httpx.Client(**self._create_client_kwargs())
+                
+                # Verify connectivity with health check
+                response = self._client.get("/health", follow_redirects=True)
+                response.raise_for_status()
+                
+                duration = time.time() - start_time
+                self._metrics.record_success(duration)
+                self._state = ConnectionState.CONNECTED
+                logger.info(f"Connected to Graphiti in {duration:.2f}s")
+            
+            return self._client
+            
+        except Exception as e:
+            self._metrics.record_failure(str(e))
+            self._state = ConnectionState.FAILED
+            logger.error(f"Failed to connect to Graphiti: {e}")
+            raise
+    
+    async def connect_async(self) -> httpx.AsyncClient:
+        """Connect to Graphiti service asynchronously."""
+        start_time = time.time()
+        self._state = ConnectionState.CONNECTING
+        
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception_type((httpx.ConnectError, httpx.TimeoutException)),
+        )
+        async def _connect():
+            if not self.config.validate_graphiti_connection():
+                raise ValueError("Invalid Graphiti configuration")
+            
+            if self._async_client is None:
+                logger.info(f"Connecting to Graphiti async at {self.config.graphiti.endpoint}")
+                self._async_client = httpx.AsyncClient(**self._create_client_kwargs())
+                
+                # Verify connectivity
+                response = await self._async_client.get("/health", follow_redirects=True)
+                response.raise_for_status()
+                
+                duration = time.time() - start_time
+                self._metrics.record_success(duration)
+                self._state = ConnectionState.CONNECTED
+                logger.info(f"Connected to Graphiti async in {duration:.2f}s")
+            
+            return self._async_client
+        
+        try:
+            return await _connect()
+        except Exception as e:
+            self._metrics.record_failure(str(e))
+            self._state = ConnectionState.FAILED
+            logger.error(f"Failed to connect to Graphiti async: {e}")
+            raise
+    
+    def request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        """Make HTTP request with retry logic."""
+        client = self.connect()
+        
+        @retry(
+            stop=stop_after_attempt(self.config.graphiti.max_retries),
+            wait=wait_exponential(
+                multiplier=self.config.graphiti.retry_delay,
+                max=self.config.graphiti.retry_delay * self.config.graphiti.retry_backoff ** 3
+            ),
+            retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+            before_sleep=lambda retry_state: self._metrics.record_retry(),
+        )
+        def _request():
+            return client.request(method, path, **kwargs)
+        
+        return _request()
+    
+    async def request_async(self, method: str, path: str, **kwargs) -> httpx.Response:
+        """Make async HTTP request with retry logic."""
+        client = await self.connect_async()
+        
+        @retry(
+            stop=stop_after_attempt(self.config.graphiti.max_retries),
+            wait=wait_exponential(
+                multiplier=self.config.graphiti.retry_delay,
+                max=self.config.graphiti.retry_delay * self.config.graphiti.retry_backoff ** 3
+            ),
+            retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+            before_sleep=lambda retry_state: self._metrics.record_retry(),
+        )
+        async def _request():
+            return await client.request(method, path, **kwargs)
+        
+        return await _request()
+    
+    def close(self):
+        """Close the connection."""
+        if self._client:
+            self._client.close()
+            self._client = None
+        self._state = ConnectionState.CLOSED
+        logger.info("Graphiti connection closed")
+    
+    async def close_async(self):
+        """Close connections asynchronously."""
+        if self._client:
+            self._client.close()
+            self._client = None
+        if self._async_client:
+            await self._async_client.aclose()
+            self._async_client = None
+        self._state = ConnectionState.CLOSED
+        logger.info("Graphiti connections closed")
+    
+    def __enter__(self):
+        """Context manager entry."""
+        self.connect()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        await self.connect_async()
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await self.close_async()
+
+
+class ConnectionPool:
+    """Connection pool for managing multiple connections."""
+    
+    def __init__(self, 
+                 manager_class: type,
+                 size: int = 5,
+                 config: Optional[RuntimeConfig] = None):
+        """Initialize connection pool."""
+        self.manager_class = manager_class
+        self.size = size
+        self.config = config or get_config()
+        self._pool: List[Any] = []
+        self._available: List[Any] = []
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._closed = False
+    
+    def _create_connection(self):
+        """Create a new connection."""
+        manager = self.manager_class(self.config)
+        if hasattr(manager, 'connect'):
+            manager.connect()
+        return manager
+    
+    @contextmanager
+    def acquire(self, timeout: Optional[float] = None):
+        """Acquire a connection from the pool."""
+        start_time = time.time()
+        
+        with self._condition:
+            while not self._available and not self._closed:
+                if len(self._pool) < self.size:
+                    # Create new connection
+                    try:
+                        conn = self._create_connection()
+                        self._pool.append(conn)
+                        self._available.append(conn)
+                        break
+                    except Exception as e:
+                        logger.error(f"Failed to create connection: {e}")
+                        raise
+                else:
+                    # Wait for available connection
+                    if timeout:
+                        remaining = timeout - (time.time() - start_time)
+                        if remaining <= 0:
+                            raise TimeoutError("Failed to acquire connection from pool")
+                        if not self._condition.wait(timeout=remaining):
+                            raise TimeoutError("Failed to acquire connection from pool")
+                    else:
+                        self._condition.wait()
+            
+            if self._closed:
+                raise RuntimeError("Connection pool is closed")
+            
+            conn = self._available.pop()
+        
+        try:
+            yield conn
+        finally:
+            with self._condition:
+                if not self._closed:
+                    self._available.append(conn)
+                    self._condition.notify()
+    
+    def close(self):
+        """Close all connections in the pool."""
+        with self._lock:
+            self._closed = True
+            for conn in self._pool:
+                try:
+                    conn.close()
+                except Exception as e:
+                    logger.error(f"Error closing connection: {e}")
+            self._pool.clear()
+            self._available.clear()
+            self._condition.notify_all()
+
+
+# Global connection managers
+_neo4j_manager: Optional[Neo4jConnectionManager] = None
+_graphiti_manager: Optional[GraphitiConnectionManager] = None
+_lock = threading.Lock()
+
+
+def get_neo4j_connection() -> Neo4jConnectionManager:
+    """Get or create global Neo4j connection manager."""
+    global _neo4j_manager
+    
+    with _lock:
+        if _neo4j_manager is None:
+            _neo4j_manager = Neo4jConnectionManager()
+        return _neo4j_manager
+
+
+def get_graphiti_connection() -> GraphitiConnectionManager:
+    """Get or create global Graphiti connection manager."""
+    global _graphiti_manager
+    
+    with _lock:
+        if _graphiti_manager is None:
+            _graphiti_manager = GraphitiConnectionManager()
+        return _graphiti_manager
+
+
+def close_all_connections():
+    """Close all global connections."""
+    global _neo4j_manager, _graphiti_manager
+    
+    with _lock:
+        if _neo4j_manager:
+            _neo4j_manager.close()
+            _neo4j_manager = None
+        if _graphiti_manager:
+            _graphiti_manager.close()
+            _graphiti_manager = None
+
+
+async def close_all_connections_async():
+    """Close all global connections asynchronously."""
+    global _neo4j_manager, _graphiti_manager
+    
+    if _neo4j_manager:
+        await _neo4j_manager.close_async()
+        _neo4j_manager = None
+    if _graphiti_manager:
+        await _graphiti_manager.close_async()
+        _graphiti_manager = None

--- a/tests/test_graphiti_connection.py
+++ b/tests/test_graphiti_connection.py
@@ -1,0 +1,416 @@
+"""
+Tests for the Graphiti connection manager module.
+"""
+
+import pytest
+import asyncio
+import time
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+from contextlib import contextmanager
+
+import httpx
+from neo4j import GraphDatabase
+from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
+
+from graphiti_connection import (
+    ConnectionState,
+    ConnectionMetrics,
+    Neo4jConnectionManager,
+    GraphitiConnectionManager,
+    ConnectionPool,
+    get_neo4j_connection,
+    get_graphiti_connection,
+    close_all_connections,
+)
+from graphiti_config import RuntimeConfig, Neo4jConfig, GraphitiConfig
+
+
+class TestConnectionMetrics:
+    """Test connection metrics tracking."""
+    
+    def test_record_success(self):
+        """Test recording successful connection."""
+        metrics = ConnectionMetrics()
+        
+        metrics.record_success(1.5)
+        
+        assert metrics.total_connections == 1
+        assert metrics.successful_connections == 1
+        assert metrics.failed_connections == 0
+        assert metrics.connection_duration == 1.5
+        assert metrics.last_connection_time is not None
+    
+    def test_record_failure(self):
+        """Test recording failed connection."""
+        metrics = ConnectionMetrics()
+        
+        metrics.record_failure("Connection refused")
+        
+        assert metrics.total_connections == 1
+        assert metrics.successful_connections == 0
+        assert metrics.failed_connections == 1
+        assert metrics.last_error == "Connection refused"
+        assert metrics.last_failure_time is not None
+    
+    def test_success_rate(self):
+        """Test success rate calculation."""
+        metrics = ConnectionMetrics()
+        
+        # No connections
+        assert metrics.success_rate == 0.0
+        
+        # Mixed results
+        metrics.record_success(1.0)
+        metrics.record_success(1.0)
+        metrics.record_failure("Error")
+        
+        assert metrics.success_rate == pytest.approx(2/3)
+
+
+class TestNeo4jConnectionManager:
+    """Test Neo4j connection manager."""
+    
+    @pytest.fixture
+    def mock_config(self):
+        """Create mock configuration."""
+        config = Mock(spec=RuntimeConfig)
+        config.neo4j = Mock(spec=Neo4jConfig)
+        config.neo4j.uri = "bolt://localhost:7687"
+        config.neo4j.password.get_secret_value.return_value = "password"
+        config.validate_neo4j_connection.return_value = True
+        config.get_neo4j_config.return_value = {
+            "uri": "bolt://localhost:7687",
+            "auth": ("neo4j", "password"),
+        }
+        return config
+    
+    def test_initialization(self, mock_config):
+        """Test connection manager initialization."""
+        manager = Neo4jConnectionManager(mock_config)
+        
+        assert manager.state == ConnectionState.DISCONNECTED
+        assert manager.metrics.total_connections == 0
+        assert manager._driver is None
+    
+    @patch('graphiti_connection.GraphDatabase')
+    def test_connect_success(self, mock_graph_db, mock_config):
+        """Test successful connection."""
+        mock_driver = Mock()
+        mock_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        driver = manager.connect()
+        
+        assert driver == mock_driver
+        assert manager.state == ConnectionState.CONNECTED
+        assert manager.metrics.successful_connections == 1
+        mock_driver.verify_connectivity.assert_called_once()
+    
+    @patch('graphiti_connection.GraphDatabase')
+    def test_connect_retry_on_service_unavailable(self, mock_graph_db, mock_config):
+        """Test retry logic on service unavailable."""
+        mock_driver = Mock()
+        mock_driver.verify_connectivity.side_effect = [
+            ServiceUnavailable("Service unavailable"),
+            None  # Success on second attempt
+        ]
+        mock_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        driver = manager.connect()
+        
+        assert driver == mock_driver
+        assert mock_driver.verify_connectivity.call_count == 2
+    
+    @patch('graphiti_connection.GraphDatabase')
+    def test_session_context_manager(self, mock_graph_db, mock_config):
+        """Test session context manager."""
+        mock_driver = Mock()
+        mock_session = Mock()
+        mock_driver.session.return_value = mock_session
+        mock_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        
+        with manager.session() as session:
+            assert session == mock_session
+        
+        mock_session.close.assert_called_once()
+    
+    @patch('graphiti_connection.GraphDatabase')
+    def test_execute_query(self, mock_graph_db, mock_config):
+        """Test query execution with retry."""
+        mock_driver = Mock()
+        mock_session = Mock()
+        mock_result = Mock()
+        mock_result.__iter__ = Mock(return_value=iter([
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 25}
+        ]))
+        
+        mock_session.run.return_value = mock_result
+        mock_driver.session.return_value = mock_session
+        mock_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        results = manager.execute_query("MATCH (n) RETURN n")
+        
+        assert len(results) == 2
+        assert results[0]["name"] == "Alice"
+        mock_session.close.assert_called_once()
+    
+    def test_state_callbacks(self, mock_config):
+        """Test state change callbacks."""
+        states = []
+        
+        manager = Neo4jConnectionManager(mock_config)
+        manager.add_state_callback(lambda state: states.append(state))
+        
+        manager._set_state(ConnectionState.CONNECTING)
+        manager._set_state(ConnectionState.CONNECTED)
+        
+        assert states == [ConnectionState.CONNECTING, ConnectionState.CONNECTED]
+    
+    @patch('graphiti_connection.AsyncGraphDatabase')
+    @pytest.mark.asyncio
+    async def test_async_connect(self, mock_async_graph_db, mock_config):
+        """Test async connection."""
+        mock_driver = AsyncMock()
+        mock_async_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        driver = await manager.connect_async()
+        
+        assert driver == mock_driver
+        assert manager.state == ConnectionState.CONNECTED
+        mock_driver.verify_connectivity.assert_awaited_once()
+    
+    @patch('graphiti_connection.AsyncGraphDatabase')
+    @pytest.mark.asyncio
+    async def test_async_session_context_manager(self, mock_async_graph_db, mock_config):
+        """Test async session context manager."""
+        mock_driver = AsyncMock()
+        mock_session = AsyncMock()
+        mock_driver.session.return_value = mock_session
+        mock_async_graph_db.driver.return_value = mock_driver
+        
+        manager = Neo4jConnectionManager(mock_config)
+        
+        async with manager.async_session() as session:
+            assert session == mock_session
+        
+        mock_session.close.assert_awaited_once()
+
+
+class TestGraphitiConnectionManager:
+    """Test Graphiti connection manager."""
+    
+    @pytest.fixture
+    def mock_config(self):
+        """Create mock configuration."""
+        config = Mock(spec=RuntimeConfig)
+        config.graphiti = Mock(spec=GraphitiConfig)
+        config.graphiti.endpoint = "http://localhost:8000"
+        config.graphiti.request_timeout = 30
+        config.graphiti.max_retries = 3
+        config.graphiti.retry_delay = 1.0
+        config.graphiti.retry_backoff = 2.0
+        config.validate_graphiti_connection.return_value = True
+        config.get_graphiti_headers.return_value = {
+            "Content-Type": "application/json"
+        }
+        return config
+    
+    def test_initialization(self, mock_config):
+        """Test connection manager initialization."""
+        manager = GraphitiConnectionManager(mock_config)
+        
+        assert manager.state == ConnectionState.DISCONNECTED
+        assert manager.metrics.total_connections == 0
+        assert manager._client is None
+    
+    @patch('httpx.Client')
+    def test_connect_success(self, mock_client_class, mock_config):
+        """Test successful connection."""
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+        
+        manager = GraphitiConnectionManager(mock_config)
+        client = manager.connect()
+        
+        assert client == mock_client
+        assert manager.state == ConnectionState.CONNECTED
+        assert manager.metrics.successful_connections == 1
+        mock_client.get.assert_called_with("/health", follow_redirects=True)
+    
+    @patch('httpx.Client')
+    def test_connect_retry_on_error(self, mock_client_class, mock_config):
+        """Test retry logic on connection error."""
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            httpx.ConnectError("Connection failed"),
+            Mock(raise_for_status=Mock())  # Success on second attempt
+        ]
+        mock_client_class.return_value = mock_client
+        
+        manager = GraphitiConnectionManager(mock_config)
+        client = manager.connect()
+        
+        assert client == mock_client
+        assert mock_client.get.call_count == 2
+    
+    @patch('httpx.Client')
+    def test_request_with_retry(self, mock_client_class, mock_config):
+        """Test HTTP request with retry."""
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_client.request.side_effect = [
+            httpx.TimeoutException("Request timeout"),
+            mock_response  # Success on second attempt
+        ]
+        mock_client.get.return_value = Mock(raise_for_status=Mock())
+        mock_client_class.return_value = mock_client
+        
+        manager = GraphitiConnectionManager(mock_config)
+        response = manager.request("POST", "/api/entity")
+        
+        assert response == mock_response
+        assert mock_client.request.call_count == 2
+        assert manager.metrics.total_retries == 1
+    
+    @patch('httpx.AsyncClient')
+    @pytest.mark.asyncio
+    async def test_async_connect(self, mock_async_client_class, mock_config):
+        """Test async connection."""
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+        mock_async_client_class.return_value = mock_client
+        
+        manager = GraphitiConnectionManager(mock_config)
+        client = await manager.connect_async()
+        
+        assert client == mock_client
+        assert manager.state == ConnectionState.CONNECTED
+        mock_client.get.assert_awaited_with("/health", follow_redirects=True)
+
+
+class TestConnectionPool:
+    """Test connection pool functionality."""
+    
+    @pytest.fixture
+    def mock_manager_class(self):
+        """Create mock connection manager class."""
+        class MockManager:
+            def __init__(self, config):
+                self.config = config
+                self.connected = False
+            
+            def connect(self):
+                self.connected = True
+            
+            def close(self):
+                self.connected = False
+        
+        return MockManager
+    
+    def test_pool_creation(self, mock_manager_class):
+        """Test connection pool creation."""
+        pool = ConnectionPool(mock_manager_class, size=3)
+        
+        assert pool.size == 3
+        assert len(pool._pool) == 0
+        assert len(pool._available) == 0
+    
+    def test_acquire_connection(self, mock_manager_class):
+        """Test acquiring connection from pool."""
+        pool = ConnectionPool(mock_manager_class, size=2)
+        
+        with pool.acquire() as conn1:
+            assert conn1.connected
+            assert len(pool._pool) == 1
+            
+            with pool.acquire() as conn2:
+                assert conn2.connected
+                assert len(pool._pool) == 2
+                assert conn1 is not conn2
+    
+    def test_connection_reuse(self, mock_manager_class):
+        """Test connection reuse in pool."""
+        pool = ConnectionPool(mock_manager_class, size=1)
+        
+        with pool.acquire() as conn1:
+            conn1.data = "test"
+        
+        with pool.acquire() as conn2:
+            assert conn2 is conn1
+            assert conn2.data == "test"
+    
+    def test_pool_exhaustion_timeout(self, mock_manager_class):
+        """Test timeout when pool is exhausted."""
+        pool = ConnectionPool(mock_manager_class, size=1)
+        
+        with pool.acquire() as conn1:
+            # Try to acquire another connection with timeout
+            with pytest.raises(TimeoutError):
+                with pool.acquire(timeout=0.1):
+                    pass
+    
+    def test_pool_close(self, mock_manager_class):
+        """Test closing connection pool."""
+        pool = ConnectionPool(mock_manager_class, size=2)
+        
+        with pool.acquire():
+            pass
+        
+        pool.close()
+        
+        assert pool._closed
+        assert len(pool._pool) == 0
+        
+        # Cannot acquire after close
+        with pytest.raises(RuntimeError):
+            with pool.acquire():
+                pass
+
+
+class TestGlobalConnectionManagers:
+    """Test global connection manager functions."""
+    
+    @patch('graphiti_connection._neo4j_manager', None)
+    @patch('graphiti_connection._graphiti_manager', None)
+    def test_get_neo4j_connection(self):
+        """Test getting global Neo4j connection."""
+        manager1 = get_neo4j_connection()
+        manager2 = get_neo4j_connection()
+        
+        assert manager1 is manager2  # Same instance
+        assert isinstance(manager1, Neo4jConnectionManager)
+    
+    @patch('graphiti_connection._neo4j_manager', None)
+    @patch('graphiti_connection._graphiti_manager', None)
+    def test_get_graphiti_connection(self):
+        """Test getting global Graphiti connection."""
+        manager1 = get_graphiti_connection()
+        manager2 = get_graphiti_connection()
+        
+        assert manager1 is manager2  # Same instance
+        assert isinstance(manager1, GraphitiConnectionManager)
+    
+    @patch('graphiti_connection._neo4j_manager')
+    @patch('graphiti_connection._graphiti_manager')
+    def test_close_all_connections(self, mock_graphiti, mock_neo4j):
+        """Test closing all global connections."""
+        mock_neo4j_instance = Mock()
+        mock_graphiti_instance = Mock()
+        mock_neo4j.return_value = mock_neo4j_instance
+        mock_graphiti.return_value = mock_graphiti_instance
+        
+        close_all_connections()
+        
+        mock_neo4j_instance.close.assert_called_once()
+        mock_graphiti_instance.close.assert_called_once()


### PR DESCRIPTION
## Summary

Implements robust connection management for Neo4j and Graphiti with automatic retry logic, connection pooling, and comprehensive error handling.

## Related Issue

Closes #23

## Changes

### Connection Managers (`graphiti_connection.py`)

#### Neo4jConnectionManager
- ✅ Automatic retry on transient failures
- ✅ Connection state tracking with callbacks
- ✅ Session management with context managers
- ✅ Query execution helpers
- ✅ Both sync and async support
- ✅ Performance metrics collection

#### GraphitiConnectionManager
- ✅ HTTP client with retry logic
- ✅ Configurable retry behavior
- ✅ Request helpers for all methods
- ✅ Health check verification
- ✅ Async request support

#### ConnectionPool
- ✅ Generic pooling for any manager type
- ✅ Thread-safe acquisition
- ✅ Connection reuse
- ✅ Configurable size and timeouts

### Key Features
- **Retry Logic**: Exponential backoff with configurable attempts
- **State Tracking**: Monitor connection states (connecting/connected/failed)
- **Metrics**: Track success rates, retry counts, and durations
- **Context Managers**: Safe resource handling
- **Global Instances**: Thread-safe singleton managers

### Additional Files
- `tests/test_graphiti_connection.py`: Comprehensive test coverage
- `examples/connection_usage.py`: Usage demonstrations
- `docs/CONNECTION_MANAGER.md`: Complete documentation

## Test Plan

- [x] Unit tests for connection managers
- [x] Retry logic verification
- [x] Connection pool tests
- [x] Async functionality tests
- [x] Mock-based external dependency testing
- [ ] Integration test with real Neo4j
- [ ] Load testing with concurrent connections

## Usage Example

```python
from graphiti_connection import get_neo4j_connection

# Automatic retry on failures
neo4j = get_neo4j_connection()
results = neo4j.execute_query(
    "MATCH (n:Person) WHERE n.age > $age RETURN n",
    {"age": 25}
)

# Connection pooling
from graphiti_connection import ConnectionPool
pool = ConnectionPool(Neo4jConnectionManager, size=5)

with pool.acquire() as conn:
    results = conn.execute_query("RETURN 1")
```

## Performance Considerations

- Connection pooling reduces overhead
- Retry logic prevents transient failure cascades
- Metrics enable performance monitoring
- Async support for high-concurrency scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)