### PR TITLE
fix: add missing import for format_as_xml

### DIFF
--- a/enhanced_nodes.py
+++ b/enhanced_nodes.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import logfire
 from pydantic import Field
+from pydantic_ai import format_as_xml
 from pydantic_graph import BaseNode, End, GraphRunContext
 
 from question_graph import (


### PR DESCRIPTION
## Summary
- Add missing import statement for `format_as_xml` from `pydantic_ai`
- Fixes #85

## Test Results from OrbStack
The import error has been resolved\! The `format_as_xml` NameError is no longer present in the test output.

### Before Fix
Tests were failing with:
```
NameError: name 'format_as_xml' is not defined
```

### After Fix
- No import errors related to `format_as_xml`
- Tests are now failing due to other unrelated issues (Bug #91 - wrong return type)
- The specific fix for Bug #85 is working correctly

### OrbStack Test Command
```bash
./run-tests-orbstack.sh
```

## Changes Made
- Added `from pydantic_ai import format_as_xml` to line 15 in `enhanced_nodes.py`
- The function is used on line 163 in the `EnhancedEvaluate` node

🤖 Generated with [Claude Code](https://claude.ai/code)